### PR TITLE
Implement show calculation details for taxes

### DIFF
--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1,28 +1,45 @@
 import { describe, it, expect } from 'vitest'
-import { calculateTaxes, getEmploymentIncomeDeduction, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax, calculateResidenceTaxBasicDeduction, calculateResidenceTax } from '../utils/taxCalculations'
+import { calculateTaxes, calculateNetEmploymentIncome, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax, calculateResidenceTaxBasicDeduction, calculateResidenceTax } from '../utils/taxCalculations'
 import { HealthInsuranceProvider } from '../types/healthInsurance'
 
-describe('getEmploymentIncomeDeduction', () => {
-  it('returns 650,000 yen for income up to 1,900,000 yen', () => {
-    expect(getEmploymentIncomeDeduction(1_500_000)).toBe(650_000)
-    expect(getEmploymentIncomeDeduction(1_900_000)).toBe(650_000)
+describe('calculateNetEmploymentIncome', () => {
+  it('deduction of 650,000 yen for income up to 1,900,000 yen', () => {
+    expect(calculateNetEmploymentIncome(1_500_000)).toBe(850_000)
+    expect(calculateNetEmploymentIncome(1_899_999)).toBe(1_249_999)
+  })
+
+  it('between 1,900,000 and 6,600,000 yen, income is rounded down to the nearest 4000 yen', () => {
+    expect(calculateNetEmploymentIncome(1_900_000)).toBe(1_250_000)
+    expect(calculateNetEmploymentIncome(1_901_123)).toBe(1_250_000)
+    expect(calculateNetEmploymentIncome(1_903_333)).toBe(1_250_000)
+    expect(calculateNetEmploymentIncome(1_904_000)).toBe(1_252_800)
+
+    expect(calculateNetEmploymentIncome(3_600_000)).toBe(2_440_000)
+    expect(calculateNetEmploymentIncome(3_603_999)).toBe(2_440_000)
+    expect(calculateNetEmploymentIncome(3_604_000)).toBe(2_443_200)
   })
 
   it('calculates deduction correctly for income between 1,900,001 and 3,600,000 yen', () => {
-    expect(getEmploymentIncomeDeduction(2_500_000)).toBe(2_500_000 * 0.3 + 80_000)
+    expect(calculateNetEmploymentIncome(2_500_000)).toBe(2_500_000 - (2_500_000 * 0.3 + 80_000))
   })
 
   it('calculates deduction correctly for income between 3,600,001 and 6,600,000 yen', () => {
-    expect(getEmploymentIncomeDeduction(5_000_000)).toBe(5_000_000 * 0.2 + 440_000)
+    expect(calculateNetEmploymentIncome(5_000_000)).toBe(5_000_000 - (5_000_000 * 0.2 + 440_000))
   })
 
   it('calculates deduction correctly for income between 6,600,001 and 8,500,000 yen', () => {
-    expect(getEmploymentIncomeDeduction(7_500_000)).toBe(7_500_000 * 0.1 + 1_100_000)
+    expect(calculateNetEmploymentIncome(7_500_000)).toBe(7_500_000 - (7_500_000 * 0.1 + 1_100_000))
+  })
+
+  it('From 6.6 million yen, income is not rounded down to the nearest 4000 yen', () => {
+    expect(calculateNetEmploymentIncome(6_600_100)).toBe(6_600_100 - (6_600_100 * 0.1 + 1_100_000))
+    expect(calculateNetEmploymentIncome(6_600_123)).toBe((Math.floor(6_600_123 * 0.9) - 1_100_000))
+    expect(calculateNetEmploymentIncome(6_601_000)).not.toBe(calculateNetEmploymentIncome(6_600_100))
   })
 
   it('returns maximum deduction of 1,950,000 yen for income above 8,500,000 yen', () => {
-    expect(getEmploymentIncomeDeduction(9_000_000)).toBe(1_950_000)
-    expect(getEmploymentIncomeDeduction(10_000_000)).toBe(1_950_000)
+    expect(calculateNetEmploymentIncome(9_000_000)).toBe(9_000_000 - 1_950_000)
+    expect(calculateNetEmploymentIncome(10_000_000)).toBe(10_000_000 - 1_950_000)
   })
 })
 

--- a/src/components/TakeHomeCalculator/TakeHomeResults.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeResults.tsx
@@ -223,7 +223,7 @@ const TakeHomeResultsDisplay: React.FC<DetailedTaxResultsProps> = ({ results }) 
         control={<Switch checked={showDetails} onChange={handleDetailsToggle} size="small" />}
         label={<Typography variant="caption">Show Calculation Details</Typography>}
         sx={{ mt: 0.5, mb: { xs: 1, sm: 1.5 }, color: 'text.secondary', alignSelf: 'flex-start' }}
-        title="Detailed breakdown coming soon!"
+        title="Show more detailed breakdown of calculations, including official sources and deduction tables."
       />
 
       <ResultRow label="Annual Income" value={formatJPY(results.annualIncome)} type="header" />

--- a/src/components/TakeHomeCalculator/TakeHomeResults.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeResults.tsx
@@ -349,7 +349,7 @@ const TakeHomeResultsDisplay: React.FC<DetailedTaxResultsProps> = ({ results }) 
                           <ul>
                             <li>
                               <a href="https://www.nta.go.jp/users/gensen/2025kiso/index.htm#a-01" target="_blank" rel="noopener noreferrer" style={{ color: '#1976d2', textDecoration: 'underline', fontSize: '0.95em' }}>
-                            令和７年度税制改正による所得税の基礎控除の見直し等について
+                                令和７年度税制改正による所得税の基礎控除の見直し等について
                               </a>
                             </li>
                             <li>

--- a/src/components/ui/DetailInfoTooltip.tsx
+++ b/src/components/ui/DetailInfoTooltip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import InfoTooltip from './InfoTooltip';
+import CalculateIcon from '@mui/icons-material/Calculate';
+
+const detailIconSx = { p: 0.25, ml: 0.3, color: 'text.secondary', verticalAlign: 'middle' };
+
+const DetailInfoTooltip: React.FC<React.ComponentProps<typeof InfoTooltip>> = (props) => (
+  <InfoTooltip
+    icon={<CalculateIcon fontSize="small" />}
+    iconSx={detailIconSx}
+    iconAriaLabel="More calculation info"
+    {...props}
+  />
+);
+
+export default DetailInfoTooltip;

--- a/src/components/ui/InfoTooltip.tsx
+++ b/src/components/ui/InfoTooltip.tsx
@@ -17,12 +17,18 @@ interface InfoTooltipProps {
   title: string;
   children?: React.ReactNode;
   mobileOnly?: boolean;
+  icon?: React.ReactNode; // Custom icon
+  iconSx?: object; // Custom icon/button style
+  iconAriaLabel?: string; // Custom aria-label
 }
 
 export const InfoTooltip: React.FC<InfoTooltipProps> = ({ 
   title, 
   children,
-  mobileOnly = false 
+  mobileOnly = false,
+  icon,
+  iconSx,
+  iconAriaLabel
 }) => {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
@@ -33,7 +39,7 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
   const handleClose = () => setOpen(false);
 
   const tooltipContent = (
-    <Box sx={{ maxWidth: 300, p: 1, fontSize: isMobile ? '0.85rem' : '1rem' }}>
+    <Box sx={{ maxWidth: 420, p: 1, fontSize: isMobile ? '0.85rem' : '1rem' }}>
       {children || title}
     </Box>
   );
@@ -44,18 +50,15 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
         <IconButton 
           onClick={handleOpen}
           size="small"
-          sx={{
-            p: 0.5,
-            ml: 0.5,
-            color: 'text.secondary',
-            '&:hover': {
-              color: 'primary.main',
-              bgcolor: 'transparent',
-            },
+          sx={{ 
+            p: 0.5, 
+            ml: 0.5, 
+            color: 'text.secondary', 
+            ...(iconSx || {}) 
           }}
-          aria-label="More information"
+          aria-label={iconAriaLabel || 'More information'}
         >
-          <HelpOutlineIcon fontSize="small" />
+          {icon || <HelpOutlineIcon fontSize="small" />}
         </IconButton>
         
         <Dialog
@@ -93,6 +96,7 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
       slotProps={{
         tooltip: {
           sx: {
+            maxWidth: 420,
             bgcolor: 'background.paper',
             color: 'text.primary',
             border: '1px solid',
@@ -111,18 +115,16 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
     >
       <IconButton 
         size="small"
-        sx={{
-          p: 0.5,
-          ml: 0.5,
-          color: 'text.secondary',
-          '&:hover': {
-            color: 'primary.main',
-            bgcolor: 'transparent',
-          },
+        sx={{ 
+          p: 0.5, 
+          ml: 0.5, 
+          color: 'text.secondary', 
+          verticalAlign: 'middle', 
+          ...(iconSx || {}) 
         }}
-        aria-label="More information"
+        aria-label={iconAriaLabel || 'More information'}
       >
-        <HelpOutlineIcon fontSize="small" />
+        {icon || <HelpOutlineIcon fontSize="small" />}
       </IconButton>
     </MuiTooltip>
   );

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -1,27 +1,33 @@
 import type { HealthInsuranceProviderId } from "./healthInsurance";
 export interface TakeHomeInputs {
-  annualIncome: number
-  isEmploymentIncome: boolean
-  isOver40: boolean
-  prefecture: string
-  showDetailedInput: boolean
+  annualIncome: number;
+  isEmploymentIncome: boolean;
+  isOver40: boolean;
+  prefecture: string;
+  showDetailedInput: boolean;
   healthInsuranceProvider: HealthInsuranceProviderId;
-  numberOfDependents: number
+  numberOfDependents: number;
 }
 
 export interface TakeHomeResults {
-  annualIncome: number
-  isEmploymentIncome: boolean
-  nationalIncomeTax: number
-  residenceTax: number
-  healthInsurance: number
-  pensionPayments: number
-  employmentInsurance?: number
-  totalTax: number
-  takeHomeIncome: number
+  annualIncome: number;
+  isEmploymentIncome: boolean;
+  nationalIncomeTax: number;
+  residenceTax: number;
+  healthInsurance: number;
+  pensionPayments: number;
+  employmentInsurance?: number;
+  totalTax: number;
+  takeHomeIncome: number;
+  // Added detailed properties
+  netEmploymentIncome?: number;
+  nationalIncomeTaxBasicDeduction?: number;
+  taxableIncomeForNationalIncomeTax?: number;
+  residenceTaxBasicDeduction?: number;
+  taxableIncomeForResidenceTax?: number;
 }
 
 export interface ChartRange {
-  min: number
-  max: number
-} 
+  min: number;
+  max: number;
+}


### PR DESCRIPTION
Enables the "Show Calculation Details" toggle and includes some details in calculating taxes for now. This can be expanded to include details about the social insurance calculations. This also fixes the calculation of the net employment income for gross employment incomes under 6.6 million, which was missing some nuances of that calculation (e.g., rounding down to the nearest 4000 yen in some cases).