### PR TITLE
Furusato nozei limit calculation

### DIFF
--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { calculateTaxes } from '../utils/taxCalculations';
+import type { FurusatoNozeiDetails } from '../types/tax';
+
+describe('calculateFurusatoNozeiLimit', () => {
+
+  it('calculates furusato nozei for the default salary', () => {
+    const fn = calculateFNForIncome(5_000_000);
+    expect(fn.limit).toBe(61_000);
+    expect(fn.outOfPocketCost).toBe(2000);
+    expect(fn.incomeTaxReduction).toBe(6000);
+    expect(fn.residenceTaxReduction).toBe(53_000);
+  });
+
+  it('calculates furusato nozei for the salary with lower out-of-pocket cost', () => {
+    const fn = calculateFNForIncome(6_000_000);
+    expect(fn.limit).toBe(77_000);
+    expect(fn.outOfPocketCost).toBe(1800);
+    expect(fn.incomeTaxReduction).toBe(7700);
+    expect(fn.residenceTaxReduction).toBe(67_500);
+  });
+
+  it('calculates furusato nozei for the salary with slightly higher out-of-pocket cost', () => {
+    const fn = calculateFNForIncome(8_800_000);
+    expect(fn.limit).toBe(151_000);
+    expect(fn.outOfPocketCost).toBe(2100);
+    expect(fn.incomeTaxReduction).toBe(30_400);
+    expect(fn.residenceTaxReduction).toBe(118_500);
+  });
+
+  it('high-income salary, high out-of-pocket cost', () => {
+    const fn = calculateFNForIncome(13_000_000);
+    expect(fn.outOfPocketCost).toBe(31_500);
+    expect(fn.limit).toBe(327_000);
+    expect(fn.incomeTaxReduction).toBe(80_000);
+    expect(fn.residenceTaxReduction).toBe(215_500);
+  });
+
+  it('mid range salary, high out-of-pocket cost', () => {
+    const fn = calculateFNForIncome(6_500_000);
+    expect(fn.limit).toBe(98_000);
+    expect(fn.outOfPocketCost).toBe(11_800);
+    expect(fn.incomeTaxReduction).toBe(9800);
+    expect(fn.residenceTaxReduction).toBe(76_400);
+  });
+
+  it('returns 0 for zero or negative taxable income', () => {
+    expect(calculateFNForIncome(0).limit).toBe(0);
+    expect(calculateFNForIncome(-1000).limit).toBe(0);
+  });
+});
+
+function calculateFNForIncome(income: number) : FurusatoNozeiDetails {
+  return calculateTaxes({
+    annualIncome: income,
+    isEmploymentIncome: true,
+    isOver40: false,
+    prefecture: 'Tokyo',
+    showDetailedInput: false,
+    healthInsuranceProvider: 'KyokaiKenpo',
+    numberOfDependents: 0
+  }).furusatoNozei;
+}

--- a/src/__tests__/residencetax.test.ts
+++ b/src/__tests__/residencetax.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { calculateResidenceTax, calculateResidenceTaxBasicDeduction } from "../utils/residenceTax"
+
+describe('calculateResidenceTaxBasicDeduction', () => {
+  it('returns 430,000 yen for income up to 24,000,000 yen', () => {
+    expect(calculateResidenceTaxBasicDeduction(0)).toBe(430_000)
+    expect(calculateResidenceTaxBasicDeduction(10_000_000)).toBe(430_000)
+    expect(calculateResidenceTaxBasicDeduction(24_000_000)).toBe(430_000)
+  })
+
+  it('returns 290,000 yen for income between 24,000,001 and 24,500,000 yen', () => {
+    expect(calculateResidenceTaxBasicDeduction(24_000_001)).toBe(290_000)
+    expect(calculateResidenceTaxBasicDeduction(24_500_000)).toBe(290_000)
+  })
+
+  it('returns 150,000 yen for income between 24,500,001 and 25,000,000 yen', () => {
+    expect(calculateResidenceTaxBasicDeduction(24_500_001)).toBe(150_000)
+    expect(calculateResidenceTaxBasicDeduction(25_000_000)).toBe(150_000)
+  })
+
+  it('returns 0 yen for income above 25,000,000 yen', () => {
+    expect(calculateResidenceTaxBasicDeduction(25_000_001)).toBe(0)
+    expect(calculateResidenceTaxBasicDeduction(30_000_000)).toBe(0)
+  })
+
+  it('handles negative income correctly', () => {
+    expect(calculateResidenceTaxBasicDeduction(-1_000_000)).toBe(430_000)
+  })
+})
+
+describe('calculateResidenceTax', () => {
+  it('calculates tax correctly for income with full deductions', () => {
+    // Example: 5M income, 1M social insurance
+    expect(calculateResidenceTax(5_000_000, 1_000_000).totalResidenceTax).toBe(359_500) // (5M - 1M - 430K) * 0.1 + 5000
+  })
+
+  it('calculates tax correctly for income with partial basic deduction', () => {
+    // Example: 24.2M income, 1M social insurance
+    expect(calculateResidenceTax(24_200_000, 1_000_000).totalResidenceTax).toBe(2_293_500) // (24.2M - 1M - 290K) * 0.1 + 5000
+  })
+
+  it('calculates tax correctly for income with minimum basic deduction', () => {
+    // Example: 24.7M income, 1M social insurance
+    expect(calculateResidenceTax(24_700_000, 1_000_000).totalResidenceTax).toBe(2_357_500) // (24.7M - 1M - 150K) * 0.1 + 5000
+  })
+
+  it('calculates tax correctly for income with no basic deduction', () => {
+    // Example: 26M income, 1M social insurance
+    expect(calculateResidenceTax(26_000_000, 1_000_000).totalResidenceTax).toBe(2_505_000) // (26M - 1M - 0) * 0.1 + 5000
+  })
+
+  it('returns minimum tax amount when deductions exceed net income', () => {
+    // Example: 1M income, 2M social insurance
+    expect(calculateResidenceTax(1_000_000, 2_000_000).totalResidenceTax).toBe(5_000) // Only 5000 yen 均等割 when taxable income is 0
+  })
+
+  it('returns 0 yen when net income is 450,000 yen or less due to 非課税制度', () => {
+    expect(calculateResidenceTax(449_999, 0).totalResidenceTax).toBe(0)
+    expect(calculateResidenceTax(450_000, 0).totalResidenceTax).toBe(0)
+  })
+
+  it('returns 5000 yen 均等割 when taxable income is 0', () => {
+    expect(calculateResidenceTax(450_001, 20_001).totalResidenceTax).toBe(5_000)
+    expect(calculateResidenceTax(1_000_000, 600_000).totalResidenceTax).toBe(5_000)
+  })
+
+  it('handles zero income correctly', () => {
+    expect(calculateResidenceTax(0, 0).totalResidenceTax).toBe(0)
+  })
+
+  it('handles negative income correctly', () => {
+    expect(calculateResidenceTax(-1_000_000, 0).totalResidenceTax).toBe(0)
+  })
+})

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateTaxes, calculateNetEmploymentIncome, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax, calculateResidenceTaxBasicDeduction, calculateResidenceTax } from '../utils/taxCalculations'
+import { calculateTaxes, calculateNetEmploymentIncome, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax } from '../utils/taxCalculations'
 import { HealthInsuranceProvider } from '../types/healthInsurance'
 
 describe('calculateNetEmploymentIncome', () => {
@@ -56,7 +56,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
-    expect(result.residenceTax).toBe(22_200)
+    expect(result.residenceTax.totalResidenceTax).toBe(22_200)
     expect(result.healthInsurance).toBe(74_916)
     expect(result.pensionPayments).toBe(138_348)
     // 1,500,000 / 12 = 125,000 per month
@@ -77,7 +77,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(22_300)
-    expect(result.residenceTax).toBe(91_100)
+    expect(result.residenceTax.totalResidenceTax).toBe(91_100)
     expect(result.healthInsurance).toBe(118_920)
     expect(result.pensionPayments).toBe(219_600)
     // 2,500,000 / 12 ≈ 208,333.33 per month
@@ -98,7 +98,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(120_700)
-    expect(result.residenceTax).toBe(243_200)
+    expect(result.residenceTax.totalResidenceTax).toBe(243_200)
     expect(result.healthInsurance).toBe(243_792)
     expect(result.pensionPayments).toBe(450_180)
     // 5,000,000 / 12 ≈ 416,666.67 per month
@@ -120,7 +120,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(16_345_400) // 50M - 1.95M (employment deduction) - 1.815194M (social insurance) - 0 (basic deduction) = 46.234806M, rounded to 46.234M, then 45% - 4.796M = 16.0093M, + 2.1% = 16.345495M, rounded down to 16.3454M
-    expect(result.residenceTax).toBe(4_628_300) // (50M - 1.95M - 1.815194M - 0) = 46.234806M, rounded to 46.234M, then 6% city tax (2.774M) + 4% prefectural tax (1.8493M) + 5K 均等割
+    expect(result.residenceTax.totalResidenceTax).toBe(4_628_300) // (50M - 1.95M - 1.815194M - 0) = 46.234806M, rounded to 46.234M, then 6% city tax (2.774M) + 4% prefectural tax (1.8493M) + 5K 均等割
     expect(result.healthInsurance).toBe(826_500) // Capped at 68,874.5 * 12
     expect(result.pensionPayments).toBe(713_700) // Capped at 59,475 * 12
     // 50,000,000 / 12 ≈ 4,166,666.67 per month
@@ -142,7 +142,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
-    expect(result.residenceTax).toBe(0)
+    expect(result.residenceTax.totalResidenceTax).toBe(0)
     expect(result.healthInsurance).toBe(0)
     expect(result.pensionPayments).toBe(0)
     expect(result.employmentInsurance).toBe(0)
@@ -160,7 +160,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
-    expect(result.residenceTax).toBe(0)
+    expect(result.residenceTax.totalResidenceTax).toBe(0)
     expect(result.healthInsurance).toBe(0)
     expect(result.pensionPayments).toBe(0)
     expect(result.employmentInsurance).toBe(0)
@@ -178,7 +178,7 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(302_700)
-    expect(result.residenceTax).toBe(384_500)
+    expect(result.residenceTax.totalResidenceTax).toBe(384_500)
     expect(result.healthInsurance).toBe(539_380)
     expect(result.pensionPayments).toBe(210_120)
     expect(result.employmentInsurance).toBe(0)
@@ -365,75 +365,3 @@ describe('calculateNationalIncomeTax', () => {
     expect(calculateNationalIncomeTax(-1_000_000)).toBe(0) // Negative income is clamped to 0
   })
 })
-
-describe('calculateResidenceTaxBasicDeduction', () => {
-  it('returns 430,000 yen for income up to 24,000,000 yen', () => {
-    expect(calculateResidenceTaxBasicDeduction(0)).toBe(430_000)
-    expect(calculateResidenceTaxBasicDeduction(10_000_000)).toBe(430_000)
-    expect(calculateResidenceTaxBasicDeduction(24_000_000)).toBe(430_000)
-  })
-
-  it('returns 290,000 yen for income between 24,000,001 and 24,500,000 yen', () => {
-    expect(calculateResidenceTaxBasicDeduction(24_000_001)).toBe(290_000)
-    expect(calculateResidenceTaxBasicDeduction(24_500_000)).toBe(290_000)
-  })
-
-  it('returns 150,000 yen for income between 24,500,001 and 25,000,000 yen', () => {
-    expect(calculateResidenceTaxBasicDeduction(24_500_001)).toBe(150_000)
-    expect(calculateResidenceTaxBasicDeduction(25_000_000)).toBe(150_000)
-  })
-
-  it('returns 0 yen for income above 25,000,000 yen', () => {
-    expect(calculateResidenceTaxBasicDeduction(25_000_001)).toBe(0)
-    expect(calculateResidenceTaxBasicDeduction(30_000_000)).toBe(0)
-  })
-
-  it('handles negative income correctly', () => {
-    expect(calculateResidenceTaxBasicDeduction(-1_000_000)).toBe(430_000)
-  })
-})
-
-describe('calculateResidenceTax', () => {
-  it('calculates tax correctly for income with full deductions', () => {
-    // Example: 5M income, 1M social insurance
-    expect(calculateResidenceTax(5_000_000, 1_000_000)).toBe(359_500) // (5M - 1M - 430K) * 0.1 + 5000
-  })
-
-  it('calculates tax correctly for income with partial basic deduction', () => {
-    // Example: 24.2M income, 1M social insurance
-    expect(calculateResidenceTax(24_200_000, 1_000_000)).toBe(2_293_500) // (24.2M - 1M - 290K) * 0.1 + 5000
-  })
-
-  it('calculates tax correctly for income with minimum basic deduction', () => {
-    // Example: 24.7M income, 1M social insurance
-    expect(calculateResidenceTax(24_700_000, 1_000_000)).toBe(2_357_500) // (24.7M - 1M - 150K) * 0.1 + 5000
-  })
-
-  it('calculates tax correctly for income with no basic deduction', () => {
-    // Example: 26M income, 1M social insurance
-    expect(calculateResidenceTax(26_000_000, 1_000_000)).toBe(2_505_000) // (26M - 1M - 0) * 0.1 + 5000
-  })
-
-  it('returns minimum tax amount when deductions exceed net income', () => {
-    // Example: 1M income, 2M social insurance
-    expect(calculateResidenceTax(1_000_000, 2_000_000)).toBe(5_000) // Only 5000 yen 均等割 when taxable income is 0
-  })
-
-  it('returns 0 yen when net income is 450,000 yen or less due to 非課税制度', () => {
-    expect(calculateResidenceTax(449_999, 0)).toBe(0)
-    expect(calculateResidenceTax(450_000, 0)).toBe(0)
-  })
-
-  it('returns 5000 yen 均等割 when taxable income is 0', () => {
-    expect(calculateResidenceTax(450_001, 20_001)).toBe(5_000)
-    expect(calculateResidenceTax(1_000_000, 600_000)).toBe(5_000)
-  })
-
-  it('handles zero income correctly', () => {
-    expect(calculateResidenceTax(0, 0)).toBe(0)
-  })
-
-  it('handles negative income correctly', () => {
-    expect(calculateResidenceTax(-1_000_000, 0)).toBe(0)
-  })
-}) 

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -13,7 +13,7 @@ export interface TakeHomeResults {
   annualIncome: number;
   isEmploymentIncome: boolean;
   nationalIncomeTax: number;
-  residenceTax: number;
+  residenceTax: ResidenceTaxDetails;
   healthInsurance: number;
   pensionPayments: number;
   employmentInsurance?: number;
@@ -24,6 +24,36 @@ export interface TakeHomeResults {
   taxableIncomeForNationalIncomeTax?: number;
   residenceTaxBasicDeduction?: number;
   taxableIncomeForResidenceTax?: number;
+  furusatoNozei: FurusatoNozeiDetails;
+}
+
+export interface ResidenceTaxDetails {
+  taxableIncome: number; // 市町村民税の課税標準額
+  cityProportion: number;
+  prefecturalProportion: number;
+  residenceTaxRate: number;
+  basicDeduction: number;
+  city: {
+    cityTaxableIncome: number;
+    cityAdjustmentCredit: number;
+    cityIncomeTax: number;
+  }
+  prefecture: {
+    prefecturalTaxableIncome: number;
+    prefecturalAdjustmentCredit: number;
+    prefecturalIncomeTax: number;
+  }
+  perCapitaTax: number;
+  totalResidenceTax: number;
+}
+
+export interface FurusatoNozeiDetails {
+  limit: number;
+  incomeTaxReduction: number;
+  residenceTaxDonationBasicDeduction: number;
+  residenceTaxSpecialDeduction: number;
+  outOfPocketCost: number;
+  residenceTaxReduction: number;
 }
 
 export interface ChartRange {

--- a/src/utils/chartConfig.ts
+++ b/src/utils/chartConfig.ts
@@ -91,7 +91,7 @@ export const generateChartData = (
       label: 'Residence Tax',
       data: incomePoints.map(income => ({
         x: income,
-        y: calculateTaxes(createTaxInputsForIncome(income)).residenceTax
+        y: calculateTaxes(createTaxInputsForIncome(income)).residenceTax.totalResidenceTax
       })),
       borderColor: 'rgb(54, 162, 235)',
       backgroundColor: 'rgba(54, 162, 235, 0.5)',

--- a/src/utils/residenceTax.ts
+++ b/src/utils/residenceTax.ts
@@ -1,0 +1,205 @@
+import type { FurusatoNozeiDetails, ResidenceTaxDetails } from "../types/tax";
+import { calculateNationalIncomeTax } from "./taxCalculations";
+
+/**
+ * Calculates the basic deduction (基礎控除) for residence tax based on income
+ * Source: https://www.machi-gr-blog.com/【住民税】給与所得控除・基礎控除の改正でどう変わる？/
+ * - 430,000 yen for income up to 24,000,000 yen
+ * - 290,000 yen for income between 24,000,001 and 24,500,000 yen
+ * - 150,000 yen for income between 24,500,001 and 25,000,000 yen
+ * - 0 yen for income above 25,000,000 yen
+ */
+export const calculateResidenceTaxBasicDeduction = (netIncome: number): number => {
+    if (netIncome <= 24000000) {
+        return 430000;
+    } else if (netIncome <= 24500000) {
+        return 290000;
+    } else if (netIncome <= 25000000) {
+        return 150000;
+    } else {
+        return 0;
+    }
+}
+
+// 非課税制度
+export const NON_TAXABLE_RESIDENCE_TAX_DETAIL: ResidenceTaxDetails = {
+    taxableIncome: 0, // 市町村民税の課税標準額
+    cityProportion: 0.6,
+    prefecturalProportion: 0.4,
+    residenceTaxRate: 0.1,
+    basicDeduction: 0,
+    city: {
+        cityTaxableIncome: 0,
+        cityAdjustmentCredit: 0,
+        cityIncomeTax: 0,
+    },
+    prefecture: {
+        prefecturalTaxableIncome: 0,
+        prefecturalAdjustmentCredit: 0,
+        prefecturalIncomeTax: 0,
+    },
+    perCapitaTax: 0,
+    totalResidenceTax: 0,
+}
+
+// 人的控除額調整控除 - 50,000 yen for the basic deduction; should be updated if other deductions are added to the calculator
+const personalDeductionDifference = 50_000;
+
+/**
+ * Calculates residence tax (住民税) based on net income and deductions
+ * Rate: 10% (6% municipal tax + 4% prefectural tax) of taxable income
+ * Taxable income = net income - social insurance deductions - residence tax basic deduction
+ * The details vary by municipality, but most deviate little from this calculation.
+ * https://www.tax.metro.tokyo.lg.jp/kazei/life/kojin_ju
+ */
+export const calculateResidenceTax = (
+    netIncome: number,
+    socialInsuranceDeduction: number,
+    taxCredit: number = 0
+): ResidenceTaxDetails => {
+    if (netIncome <= 450_000) {
+        return NON_TAXABLE_RESIDENCE_TAX_DETAIL;
+    }
+    const residenceTaxRate = 0.1;
+    const cityProportion = 0.6;
+    const prefecturalProportion = 0.4;
+    const basicDeduction = calculateResidenceTaxBasicDeduction(netIncome);
+    const taxableIncome = Math.floor(Math.max(0, netIncome - socialInsuranceDeduction - basicDeduction) / 1000) * 1000;
+
+    // 調整控除額
+    let adjustmentCredit = 0;
+    if (netIncome <= 2_000_000) {
+        adjustmentCredit = Math.min(personalDeductionDifference * 0.05, taxableIncome * 0.05);
+    } else if (netIncome <= 25_000_000) {
+        adjustmentCredit = Math.max((personalDeductionDifference - (taxableIncome - 2_000_000)) * 0.05, personalDeductionDifference * 0.05);
+    }
+    const cityAdjustmentCredit = adjustmentCredit * cityProportion;
+    const prefecturalAdjustmentCredit = adjustmentCredit * prefecturalProportion;
+
+    const cityIncomeTax = Math.floor(((taxableIncome * 0.06) - cityAdjustmentCredit - (taxCredit * cityProportion)) / 100) * 100;
+    const prefecturalIncomeTax = Math.floor(((taxableIncome * 0.04) - prefecturalAdjustmentCredit - (taxCredit * prefecturalProportion)) / 100) * 100;
+    const perCapitaTax = 5000; // 均等割額 (fixed amount per person, varies by municipality)
+
+    return {
+        taxableIncome,
+        cityProportion,
+        prefecturalProportion,
+        residenceTaxRate,
+        basicDeduction,
+        city: {
+            cityTaxableIncome: taxableIncome * cityProportion,
+            cityAdjustmentCredit,
+            cityIncomeTax,
+        },
+        prefecture: {
+            prefecturalTaxableIncome: taxableIncome * prefecturalProportion,
+            prefecturalAdjustmentCredit,
+            prefecturalIncomeTax,
+        },
+        perCapitaTax,
+        totalResidenceTax: cityIncomeTax + prefecturalIncomeTax + perCapitaTax,
+    };
+}
+
+// ふるさと納税の自己負担額
+const FURUSATO_OUT_OF_POCKET_COST = 2000;
+// 基本控除率 (ふるさと納税の寄付金控除の基本控除率)
+const donationBasicDeductionRate = 0.1;
+
+/**
+ * Calculate the maximum deductible ふるさと納税 (Furusato Nozei) donation limit for which the user's out-of-pocket cost is ~2,000 yen.
+ *
+ * @param taxableIncomeForNationalIncomeTax - Taxable income for national income tax, before rounding (所得税課税所得)
+ * @param residenceTaxDetails - Details of the residence tax, including taxable income and rates
+ * @returns The various details of the Furusato Nozei deduction, including the limit, out-of-pocket cost, and tax reductions.
+ * @see https://kaikei7.com/furusato_nouzei_keisan/
+ * @see https://kaikei7.com/furusato_nouzei_onestop/
+ */
+export function calculateFurusatoNozeiDetails(
+    taxableIncomeForNationalIncomeTax: number,
+    residenceTaxDetails: ResidenceTaxDetails
+): FurusatoNozeiDetails {
+    if (taxableIncomeForNationalIncomeTax <= 0 || residenceTaxDetails.taxableIncome <= 0) {
+        return {
+            limit: 0,
+            incomeTaxReduction: 0,
+            residenceTaxDonationBasicDeduction: 0,
+            residenceTaxSpecialDeduction: 0,
+            outOfPocketCost: 0,
+            residenceTaxReduction: 0
+        };
+    }
+    // 調整控除後 所得割
+    const residentTaxAmountForIncomePortion = residenceTaxDetails.totalResidenceTax - residenceTaxDetails.perCapitaTax;
+
+    // Special deduction rate for resident tax (特例控除割合)
+    const specialDeductionRate = getSpecialDeductionMultiplier(residenceTaxDetails.taxableIncome - personalDeductionDifference);
+
+    // The deduction breakdown:
+    // Income tax deduction: (X - 2000) * incomeTaxRate (not used if one-stop)
+    // Resident tax basic deduction (基本控除): (X - 2000) * residenceTaxRate
+    // Resident tax special deduction (特例控除): (X - 2000) * (1 - residenceTaxRate - marginalIncomeTaxRate) [capped at 20% of resident tax amount for the income portion]
+    // One-stop special deduction (申告特例控除): 
+
+    // We need to find X such that:
+    // (X - 2000) * specialDeductionRate <= residentTaxAmountForIncomePortion * 0.2
+    const maxSpecialDeduction = residentTaxAmountForIncomePortion * 0.2;
+    const furusatoNozeiLimit = maxSpecialDeduction / specialDeductionRate + FURUSATO_OUT_OF_POCKET_COST;
+
+    // Statutory cap: donation cannot exceed 30% of resident tax taxable income
+    // This will always be higher than the 20% cap for the special deduction
+    const statutoryCap = residenceTaxDetails.taxableIncome * 0.3;
+
+    // Final limit is the lower of the two, rounded down to the nearest 1,000 yen
+    const finalLimit = Math.floor(Math.min(furusatoNozeiLimit, statutoryCap) / 1000) * 1000;
+    const deductibleDonation = Math.max(finalLimit - FURUSATO_OUT_OF_POCKET_COST, 0);
+    // const incomeTaxReduction = deductibleDonation * (1 - specialDeductionRate - donationBasicDeductionRate);
+    const incomeTaxReduction = calculateIncomeTaxReduction(taxableIncomeForNationalIncomeTax, deductibleDonation);
+    const residenceTaxDonationBasicDeduction = deductibleDonation * donationBasicDeductionRate;
+    let residenceTaxSpecialDeduction = deductibleDonation * specialDeductionRate;
+    residenceTaxSpecialDeduction = Math.ceil(residenceTaxSpecialDeduction * residenceTaxDetails.cityProportion) + Math.ceil(residenceTaxSpecialDeduction * residenceTaxDetails.prefecturalProportion);
+
+    const furusatoNozeiTaxCredit = residenceTaxDonationBasicDeduction + residenceTaxSpecialDeduction;
+    const beforeCityIncomeTax = residenceTaxDetails.city.cityTaxableIncome * residenceTaxDetails.residenceTaxRate - residenceTaxDetails.city.cityAdjustmentCredit;
+    const cityIncomeTaxWithFurusato = Math.floor((beforeCityIncomeTax - Math.ceil(furusatoNozeiTaxCredit * residenceTaxDetails.cityProportion)) / 100) * 100;
+    const beforePrefectureIncomeTax = residenceTaxDetails.prefecture.prefecturalTaxableIncome * residenceTaxDetails.residenceTaxRate - residenceTaxDetails.prefecture.prefecturalAdjustmentCredit;
+    const prefectureIncomeTaxWithFurusato = Math.floor((beforePrefectureIncomeTax - Math.ceil(furusatoNozeiTaxCredit * residenceTaxDetails.prefecturalProportion)) / 100) * 100;
+    const residenceTaxDifference = (residenceTaxDetails.totalResidenceTax) - (cityIncomeTaxWithFurusato + prefectureIncomeTaxWithFurusato + residenceTaxDetails.perCapitaTax);
+
+    return {
+        limit: finalLimit,
+        incomeTaxReduction,
+        residenceTaxDonationBasicDeduction,
+        residenceTaxSpecialDeduction,
+        residenceTaxReduction: residenceTaxDifference,
+        outOfPocketCost: finalLimit - residenceTaxDifference - incomeTaxReduction
+    };
+}
+
+function calculateIncomeTaxReduction(taxableIncome: number, furusatoNozeiDeduction: number): number {
+    const incomeTaxBefore = calculateNationalIncomeTax(Math.floor(taxableIncome / 1000) * 1000);
+    const incomeTaxAfter = calculateNationalIncomeTax(Math.floor((taxableIncome - furusatoNozeiDeduction) / 1000) * 1000);
+
+    return incomeTaxBefore - incomeTaxAfter;
+}
+
+/**
+ * 
+ * @param taxableIncome taxable income for residence tax (住民税の課税総所得金額)
+ * @returns 特例控除割合
+ * @see 地方税法第37条の二
+ */
+function getSpecialDeductionMultiplier(taxableIncome: number): number {
+    let incomeTaxRate = 0;
+    if (taxableIncome <= 1950000) incomeTaxRate = 0.05;
+    else if (taxableIncome <= 3300000) incomeTaxRate = 0.10;
+    else if (taxableIncome <= 6950000) incomeTaxRate = 0.20;
+    else if (taxableIncome <= 9000000) incomeTaxRate = 0.23;
+    else if (taxableIncome <= 18000000) incomeTaxRate = 0.33;
+    else if (taxableIncome <= 40000000) incomeTaxRate = 0.40;
+    else incomeTaxRate = 0.45; // Over 40 million
+
+    incomeTaxRate *= 1.021; // Add 2.1% surtax
+
+    return 1 - donationBasicDeductionRate - incomeTaxRate;
+}


### PR DESCRIPTION
Calculate the furusato nozei donation limit based on the inputs.
This can only be accurate if the deductions supported by the calculator match the deductions of the user.
Some incomes will result in a limit with more than a 2000 yen out of pocket cost.
The one-stop system avoids this issue, and the UI will visually warn the user about this situation.

The calculations are based on the great tool and explanations from https://kaikei7.com/furusato_nouzei_keisan/